### PR TITLE
Julenmendieta/removeTelegram

### DIFF
--- a/.changeset/cold-regions-beg.md
+++ b/.changeset/cold-regions-beg.md
@@ -1,0 +1,10 @@
+---
+"@platforma-open/milaboratories.rarefaction": patch
+"@platforma-open/milaboratories.rarefaction.model": patch
+"@platforma-open/milaboratories.rarefaction.software": patch
+"@platforma-open/milaboratories.rarefaction.test": patch
+"@platforma-open/milaboratories.rarefaction.ui": patch
+"@platforma-open/milaboratories.rarefaction.workflow": patch
+---
+
+Remove telegram

--- a/.github/workflows/mark-stable.yaml
+++ b/.github/workflows/mark-stable.yaml
@@ -17,7 +17,6 @@ jobs:
     uses: milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4
     with:
       app-name: 'Block: rarefaction - Mark Stable'
-      notify-telegram: true
       node-version: '20.x'
       npmrc-config: |
         {
@@ -33,5 +32,5 @@ jobs:
         { "NPMJS_TOKEN": ${{ toJSON(secrets.NPMJS_TOKEN) }},
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }} }
 
-      TELEGRAM_NOTIFICATION_TARGET: ${{ secrets.TG_CHANNEL_MIBUILDS }}
-      TELEGRAM_API_TOKEN: ${{ secrets.TG_CI_BOT_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes Telegram CI notifications from the `mark-stable` workflow and replaces them with Slack notifications, matching the pattern already used in `build.yaml`. A changeset entry is also added to record a patch bump across all rarefaction packages.

- Removes `notify-telegram: true` and the two Telegram secrets (`TELEGRAM_NOTIFICATION_TARGET`, `TELEGRAM_API_TOKEN`) from `.github/workflows/mark-stable.yaml`, replacing them with `SLACK_BOT_TOKEN` and `SLACK_CHANNEL` — bringing this workflow in line with `build.yaml`.
- Adds a changeset file marking a patch release for all six rarefaction packages with the message "Remove telegram".
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change swaps two Telegram secrets for two Slack secrets in a manually-triggered workflow, mirroring the notification setup already live in build.yaml.

Both changed files are straightforward: the workflow change is a direct like-for-like substitution of notification secrets, and the changeset file correctly documents all affected packages. No logic, build steps, or publishing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mark-stable.yaml | Removes Telegram notification config and replaces with Slack secrets, consistent with the existing build.yaml pattern. |
| .changeset/cold-regions-beg.md | New changeset file registering a patch bump for all six rarefaction packages with the "Remove telegram" description. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant WF as block-mark-stable.yaml@v4
    participant Slack as Slack (SLACK_BOT_TOKEN)

    GHA->>WF: workflow_dispatch trigger
    WF->>WF: build / mark stable
    WF->>Slack: post notification to SLACK_BLOCKS_CI_CHANNEL
    Note over WF,Slack: Previously sent to Telegram (TG_CHANNEL_MIBUILDS)<br/>Now uses Slack — consistent with build.yaml
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/rarefaction/commit/60ead39208c3b7d8a8e8037dd0b1d6e7d565aab6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32625251)</sub>

<!-- /greptile_comment -->