### PR TITLE
fix(ci): PR builds use build:dev-local, publish uses build:release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,8 @@ jobs:
       app-name: 'Block: Rarefaction'
       app-name-slug: 'block-rarefaction'
       node-version: '20.x'
-      build-script-name: 'build:release'
+      build-script-name: 'build:dev-local'
+      build-before-publish-script-name: 'build:release'
       pnpm-recursive-build: false
 
       test: true


### PR DESCRIPTION
## Problem

The structurer migration (#32) left the build workflow calling `build:release` for **all** builds:

```yaml
build-script-name: 'build:release'   # PL_BUILD_CHANNEL=release, LOCATION=remote
```

So PR and merge-queue validation runs the **release channel** — remote software upload — which is wrong for validating a PR.

(Root cause was upstream: block-tools' `build.tpl.yaml` originally generated `build-script-name: 'build'`, a script the structurer had removed. Fixed the template in [platforma#1744](https://github.com/milaboratory/platforma/pull/1744); this PR applies the correct config to rarefaction now.)

## Fix

The reusable `node-simple-pnpm.yaml` has two build legs — PR/test (`build-script-name`) and publish (`build-before-publish-script-name`). Wire each to the right flavor:

```yaml
build-script-name: 'build:dev-local'                # PR/merge-queue: local validation
build-before-publish-script-name: 'build:release'   # publish: release channel
```

Once block-tools#1744 ships and rarefaction bumps the SDK, a `structure refresh` will regenerate exactly this — no drift.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CI workflow so that PR/merge-queue validation uses `build:dev-local` (local, dev channel) while the publish step retains `build:release` (remote, release channel). The prior state had a single `build-script-name: 'build:release'` for all builds, causing every PR check to trigger a remote release-channel build — incorrect behavior left behind by the structurer migration in #32.

- **`build-script-name`** changed from `build:release` to `build:dev-local`: PR and merge-queue runs now execute `PL_BUILD_CHANNEL=dev PL_BUILD_LOCATION=local`, keeping validation self-contained and avoiding remote software uploads.
- **`build-before-publish-script-name: 'build:release'`** added: publish runs continue to use `PL_BUILD_CHANNEL=release PL_BUILD_LOCATION=remote`, ensuring release artifacts are built with the correct channel settings.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both `build:dev-local` and `build:release` scripts are confirmed present in the root `package.json`, and the parameter split correctly maps each CI leg to the right build flavor.

The change is a two-line YAML correction that wires pre-existing scripts to the appropriate CI legs. `build:dev-local` and `build:release` both exist at the repo root and have the expected env-var combinations. No logic is altered elsewhere.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yaml | Splits the single `build-script-name: 'build:release'` into the correct two-parameter setup: `build:dev-local` for PR/merge-queue and `build:release` for publish. Both scripts are confirmed present in root `package.json`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event] --> B{Event Type?}
    B -->|pull_request / merge_group| C[build-script-name\nbuild:dev-local]
    B -->|push to main / publish| D[build-before-publish-script-name\nbuild:release]

    C --> E[PL_BUILD_CHANNEL=dev\nPL_BUILD_LOCATION=local\nturbo run build]
    D --> F[PL_BUILD_CHANNEL=release\nPL_BUILD_LOCATION=remote\nturbo run build]

    E --> G[Local validation — no remote upload]
    F --> H[Release artifacts published remotely]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GitHub Event] --> B{Event Type?}
    B -->|pull_request / merge_group| C[build-script-name\nbuild:dev-local]
    B -->|push to main / publish| D[build-before-publish-script-name\nbuild:release]

    C --> E[PL_BUILD_CHANNEL=dev\nPL_BUILD_LOCATION=local\nturbo run build]
    D --> F[PL_BUILD_CHANNEL=release\nPL_BUILD_LOCATION=remote\nturbo run build]

    E --> G[Local validation — no remote upload]
    F --> H[Release artifacts published remotely]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): PR builds use build:dev-local, ..."](https://github.com/platforma-open/rarefaction/commit/59dbce64298046a6f979925e193ca7e70817a529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42996365)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->