### PR TITLE
chore: republish software against upgraded SDK

### DIFF
--- a/.changeset/republish-software.md
+++ b/.changeset/republish-software.md
@@ -1,0 +1,6 @@
+---
+"@platforma-open/milaboratories.rarefaction.software": patch
+"@platforma-open/milaboratories.rarefaction.workflow": patch
+---
+
+Rebuild and republish software against the upgraded SDK


### PR DESCRIPTION
Adds a changeset to republish the software package(s) against the upgraded SDK. The merged `chore/upgrade-sdk` PR bumped model/ui/workflow but omitted the software package, so the software artifacts were never rebuilt. This patches the software package (and workflow, which references it) so a new software version is published on merge.